### PR TITLE
Add ordinal number conditional to prevent row placement breaks.

### DIFF
--- a/lib/board.rb
+++ b/lib/board.rb
@@ -35,7 +35,12 @@ class Board
   end
 
   def valid_horiz?(ship, coordinates)
-    @cells.keys.each_cons(ship.length).any? { |consec| coordinates == consec }
+    coord_ord = coordinates.map { |coord| coord.ord }
+    if coordinates.all? { |coord| coord.ord == coord_ord[0] }
+      @cells.keys.each_cons(ship.length).any? { |consec| coordinates == consec }
+    else 
+      false
+    end
   end
 
   def valid_vertical?(ship, coordinates)

--- a/test/board_test.rb
+++ b/test/board_test.rb
@@ -44,6 +44,7 @@ class BoardTest < Minitest::Test
   def test_valid_placements_cannot_be_diagonal
     assert_equal false, @board.valid_placement?(@submarine, ["C1", "B1"])
     assert_equal false, @board.valid_placement?(@cruiser, ["A1", "B2", "C3"])
+    assert_equal false, @board.valid_placement?(@cruiser, ["A3", "A4", "B1"])
     assert_equal false, @board.valid_placement?(@submarine, ["C2", "D3"])
   end
 


### PR DESCRIPTION
Add ordinal number conditional to prevent row placement breaks.